### PR TITLE
Fix minor README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is the documentation for the Community-supported HTML5 Platform Extension f
 * * *
 
 After **linking your [Epic Games Account](https://www.epicgames.com/account/connected) to your GitHub account**,
-you can find the HTML5 Platform Extenion repository [HERE](https://github.com/UnrealEngineHTML5/UnrealEngine/tree/4.24.3-html5-1.39.18/Engine/Platforms/HTML5).
+you can find the HTML5 Platform Extension repository [HERE](https://github.com/UnrealEngineHTML5/UnrealEngine/tree/4.24.3-html5-1.39.18/Engine/Platforms/HTML5).
 
 - NOTE: if you still see a `404 This is not the web page you are looking for` error
 	- Double check you have linked your Epic Games and GitHub accounts [#12](https://github.com/UnrealEngineHTML5/Documentation/issues/12#issuecomment-597729773)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the documentation for the Community-supported HTML5 Platform Extension f
 	- latest documentation
 
 - [Unreal Engine 4 HTML5 Platform Documentation](Platforms/HTML5/HTML5.md)
-	- older, but may have addtional information that might be useful
+	- older, but may have additional information that might be useful
 
 * * *
 
@@ -22,7 +22,7 @@ you can find the HTML5 Platform Extension repository [HERE](https://github.com/U
 		[#8](https://github.com/UnrealEngineHTML5/Documentation/issues/8#issuecomment-587092613)
 		[#12](https://github.com/UnrealEngineHTML5/Documentation/issues/12#issuecomment-632891334)
 		[#25](https://github.com/UnrealEngineHTML5/Documentation/issues/25#issuecomment-632911377)
-		- You **MAY** Have to wait for a bit (usually less than 24 hours) before access is granted
+		- You **MAY** have to wait for a bit (usually less than 24 hours) before access is granted
 			[#7](https://github.com/UnrealEngineHTML5/Documentation/issues/7#issuecomment-585872314)
 			[#35](https://github.com/UnrealEngineHTML5/Documentation/issues/35#issuecomment-636389033)
 	- Please see all [**Open and Closed** HTML5 404 issues](https://github.com/UnrealEngineHTML5/Documentation/labels/404) for more tips


### PR DESCRIPTION
Small typos in the README.md
"Extenion" -> "Extension"
"addtional" -> "additional"